### PR TITLE
Big refactoring, and validation now as fast as indexing

### DIFF
--- a/opal-core-api/src/main/java/org/obiba/opal/core/service/ValidationService.java
+++ b/opal-core-api/src/main/java/org/obiba/opal/core/service/ValidationService.java
@@ -6,33 +6,33 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 import org.obiba.magma.Value;
 import org.obiba.magma.ValueTable;
-import org.obiba.magma.Variable;
-import org.obiba.magma.VariableEntity;
+import org.obiba.magma.concurrent.ConcurrentValueTableReader.ConcurrentReaderCallback;
 import org.obiba.opal.core.support.MessageLogger;
 
-import javax.validation.ValidationException;
 import java.util.*;
 
 /**
  * Service for validation.
- * The validation itself is done inside the ValidationTask.
  */
 public interface ValidationService {
 
     public static final String VALIDATE_ATTRIBUTE = "validate";
 
     /**
-     * @param valueTable table to be validated
+     * @param valueTable table to validate data
      * @param logger
-     * @return new validation task for the given table and listener, or null if validation is not enabled for that table.
+     * @return result of validation, or null if not enabled/required for the given table
      */
-    ValidationTask createValidationTask(ValueTable valueTable, MessageLogger logger);
+    ValidationResult validate(ValueTable valueTable, MessageLogger logger);
 
     /**
+     * Creates a validating ConcurrentReaderCallback wrapping the given one, if validations are configured, or null otherwise.
      * @param valueTable
-     * @return true if validation is enabled for the given table.
+     * @param delegate
+     * @param logger
+     * @return wrapper validating callback, or null
      */
-    boolean isValidationEnabled(ValueTable valueTable);
+    ConcurrentReaderCallback createValidatingCallback(ValueTable valueTable, ConcurrentReaderCallback delegate, MessageLogger logger);
 
     /**
      * Container for validation results.
@@ -87,30 +87,4 @@ public interface ValidationService {
         }
     }
 
-    /**
-     * Represents a delayed validation task that is aware of the table under validation.
-     */
-    public interface ValidationTask {
-
-        /**
-         * @return list of names of variables under validation
-         */
-        List<String> getVariableNames();
-
-        /**
-         * Validates the given value for variable.
-         * @param variable
-         * @param value
-         * @param entity
-         * @throws ValidationException if the given value is not valid
-         */
-        void validate(Variable variable, Value value, VariableEntity entity) throws ValidationException;
-
-        /**
-         * Validates the whole table data, collecting and returning the results
-         * @return
-         */
-        ValidationResult validate();
-    }
-    
 }

--- a/opal-core/src/main/java/org/obiba/opal/core/service/ValidationServiceImpl.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/ValidationServiceImpl.java
@@ -1,26 +1,23 @@
 package org.obiba.opal.core.service;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.obiba.magma.*;
-import org.obiba.magma.Value;
+import org.obiba.magma.ValueTable;
+import org.obiba.magma.Variable;
+import org.obiba.magma.concurrent.ConcurrentValueTableReader.ConcurrentReaderCallback;
 import org.obiba.opal.core.service.validation.DataConstraint;
+import org.obiba.opal.core.service.validation.ValidationTask;
+import org.obiba.opal.core.service.validation.ValidatingCallback;
 import org.obiba.opal.core.service.validation.ValidatorFactory;
 import org.obiba.opal.core.support.MessageLogger;
-import org.springframework.beans.factory.annotation.*;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.support.TransactionCallbackWithoutResult;
-import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.validation.ValidationException;
-import javax.validation.constraints.NotNull;
-import java.util.*;
+import java.util.List;
+import java.util.concurrent.ThreadFactory;
 
 @Component
 public class ValidationServiceImpl implements ValidationService {
-
-    @Autowired
-    private TransactionTemplate txTemplate;
 
     @Autowired
     ValidatorFactory validatorFactory;
@@ -28,8 +25,11 @@ public class ValidationServiceImpl implements ValidationService {
     @org.springframework.beans.factory.annotation.Value("${org.obiba.opal.validation.skip:false}")
     private boolean skipValidation;
 
-    @Override
-    public boolean isValidationEnabled(ValueTable valueTable) {
+    @Autowired
+    private ThreadFactory threadFactory;
+
+    @VisibleForTesting
+    boolean isValidationEnabled(ValueTable valueTable) {
         //@todo improve this when either project or table have attributes
         if (skipValidation) {
             return false;
@@ -38,110 +38,33 @@ public class ValidationServiceImpl implements ValidationService {
         return valueTable.isView(); //only views have validation enabled by default
     }
 
-    private ValidationResult validateInTransaction(final ValueTable valueTable, final MessageLogger logger,
-                                      final Map<String, List<DataConstraint>> validatorMap) {
-
-        if (!isValidationEnabled(valueTable)) {
+    @Override
+    @Transactional(readOnly = true)
+    public ValidationResult validate(ValueTable valueTable, MessageLogger logger) {
+        ValidationTask task = createValidationTask(valueTable, logger);
+        if (task == null) {
             return null;
         }
-
-        final ValidationResult result = new ValidationResult();
-
-        final Runnable task = new Runnable() {
-            @Override
-            public void run() {
-                collectResults(valueTable, logger, validatorMap, result);
-            }
-        };
-
-        txTemplate.execute(
-                new TransactionCallbackWithoutResult() {
-                    @Override
-                    protected void doInTransactionWithoutResult(TransactionStatus status) {
-                        task.run();
-                        //status.flush();
-                    }
-                });
-
-        return result;
-    }
-
-    /**
-     * For testing purposes only.
-     * Creates a validation task and runs the validation with no transaction/real database required
-     * @param valueTable
-     * @param logger
-     * @return
-     */
-    @VisibleForTesting
-    ValidationResult validateNoTransaction(ValueTable valueTable, MessageLogger logger) {
-        InternalValidationTask task = createInternalValidationTask(valueTable, logger);
-        final ValidationResult result = new ValidationResult();
-        collectResults(valueTable, logger, task.constraintMap, result);
-        return result;
-    }
-
-    private Set<String> getRuleTypes(List<DataConstraint> validators) {
-        Set<String> result = new HashSet<>();
-        for (DataConstraint validator: validators) {
-            result.add(validator.getType());
-        }
-        return result;
-    }
-
-    private void collectResults(ValueTable valueTable,
-                                final MessageLogger logger,
-                                Map<String, List<DataConstraint>> constraintMap,
-                                ValidationResult collector) {
-
-        logger.info("Validating table %s.%s", valueTable.getDatasource().getName(), valueTable.getName());
-
-        for (Map.Entry<String,List<DataConstraint>> entry: constraintMap.entrySet()) {
-            collector.setRules(entry.getKey(), getRuleTypes(entry.getValue()));
-        }
-
-        for (ValueSet vset : valueTable.getValueSets()) {
-            for (Map.Entry<String, List<DataConstraint>> entry : constraintMap.entrySet()) {
-                String varName = entry.getKey();
-                Value value = valueTable.getValue(valueTable.getVariable(varName), vset);
-
-                if (value.isSequence()) {
-                    ValueSequence seq = value.asSequence();
-                    for (Value val: seq.getValue()) {
-                        validate(varName, entry.getValue(), logger, collector, val, vset.getVariableEntity().getIdentifier());
-                    }
-                } else {
-                    validate(varName, entry.getValue(), logger, collector, value, vset.getVariableEntity().getIdentifier());
-                }
-            }
-        }
-    }
-
-    private void validate(String varName, List<DataConstraint> constraints, MessageLogger logger,
-                          ValidationResult collector, Value value, String id) {
-
-        for (DataConstraint constraint : constraints) {
-            if (!constraint.isValid(value)) {
-                logger.warn(getMessage(id, varName, value.toString(), constraint));
-                collector.addFailure(varName, constraint.getType(), value);
-            }
-        }
+        return task.validate(valueTable);
     }
 
     @Override
-    public ValidationTask createValidationTask(ValueTable valueTable, MessageLogger logger) {
-        InternalValidationTask task = createInternalValidationTask(valueTable, logger);
-        if (task.isEmpty()) {
-            return null; //noting to validate
+    public ConcurrentReaderCallback createValidatingCallback(ValueTable valueTable,
+                                                             ConcurrentReaderCallback delegate,
+                                                             MessageLogger logger) {
+
+        ValidationTask task = createValidationTask(valueTable, logger);
+        if (task == null) {
+            return null; //no validation required
         }
 
-        return task;
+        return new ValidatingCallback(task, delegate);
     }
 
-    private InternalValidationTask createInternalValidationTask(ValueTable valueTable, MessageLogger logger) {
-        InternalValidationTask task = new InternalValidationTask(valueTable, logger);
+    private ValidationTask createValidationTask(ValueTable valueTable, MessageLogger logger) {
 
         if (isValidationEnabled(valueTable)) {
+            ValidationTask task = new ValidationTask(logger, threadFactory);
             for (Variable var: valueTable.getVariables()) {
                 List<DataConstraint> constraints = validatorFactory.getValidators(valueTable, var);
                 if (constraints != null && constraints.size() > 0) {
@@ -149,64 +72,13 @@ public class ValidationServiceImpl implements ValidationService {
                     task.addConstraints(var, constraints);
                 }
             }
-        }
 
-        return task;
-    }
-
-    private static String getMessage(String entityId, String variable, String value, DataConstraint constraint) {
-        return String.format("Validation failed: EntityId %s, Variable %s, Value %s: %s",
-                entityId,
-                variable,
-                value,
-                constraint.getMessage());
-    }
-
-    private class InternalValidationTask implements ValidationTask {
-
-        @NotNull
-        private final ValueTable valueTable;
-
-        @NotNull
-        private final MessageLogger logger;
-
-        private final Map<String, List<DataConstraint>> constraintMap = new HashMap<>();
-
-        public InternalValidationTask(ValueTable valueTable, MessageLogger logger) {
-            this.valueTable = valueTable;
-            this.logger = logger;
-        }
-
-        private void addConstraints(Variable var, List<DataConstraint> constraints) {
-            constraintMap.put(var.getName(), constraints);
-        }
-
-        private boolean isEmpty() {
-            return constraintMap.isEmpty();
-        }
-
-        @Override
-        public List<String> getVariableNames() {
-            return new ArrayList<>(constraintMap.keySet());
-        }
-
-
-        @Override
-        public void validate(Variable variable, Value value, VariableEntity entity) throws ValidationException {
-            List<DataConstraint> constraints = constraintMap.get(variable.getName());
-            if (constraints != null) {
-                for (DataConstraint constraint: constraints) {
-                    if (!constraint.isValid(value)) {
-                        String msg = getMessage(entity.getIdentifier(), variable.getName(), value.toString(), constraint);
-                        throw new ValidationException(msg);
-                    }
-                }
+            if (!task.isEmpty()) {
+                return task; //only return task if some validation exist
             }
         }
 
-        @Override
-        public ValidationResult validate() {
-            return ValidationServiceImpl.this.validateInTransaction(valueTable, logger, constraintMap);
-        }
+        return null;
     }
+
 }

--- a/opal-core/src/main/java/org/obiba/opal/core/service/validation/BaseValidatingCallback.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/validation/BaseValidatingCallback.java
@@ -1,0 +1,66 @@
+package org.obiba.opal.core.service.validation;
+
+import org.obiba.magma.Value;
+import org.obiba.magma.Variable;
+import org.obiba.magma.VariableEntity;
+import org.obiba.magma.concurrent.ConcurrentValueTableReader;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+/**
+ * Base validation behavior for ConcurrentReaderCallbacks
+ */
+public abstract class BaseValidatingCallback implements ConcurrentValueTableReader.ConcurrentReaderCallback {
+
+    @NotNull
+    protected final ValidationTask validationTask;
+
+    private List<String> validationVariables;
+
+    public BaseValidatingCallback(ValidationTask validationTask) {
+        this.validationTask = validationTask;
+    }
+
+    @Override
+    public void onBegin(List<VariableEntity> entities, Variable... variables) {
+        this.validationVariables = validationTask.getVariableNames();
+    }
+
+    @Override
+    public final void onValues(VariableEntity entity, Variable[] variables, Value... values) {
+        for(int i = 0; i<variables.length; i++) {
+            Variable var = variables[i];
+
+            if (!validationVariables.contains(var.getName())) {
+                continue; //variable not validated: ignore
+            }
+
+            Value value = values[i];
+
+            if (value.isNull()) {
+                //we dont validate null: only useful if we have a NotNull validation rule, and make all other rules accept null
+            } else if (value.isSequence()) {
+                for (Value val: value.asSequence().getValue()) {
+                    if (val.isNull()) {
+                        //we dont validate null: only useful if we have a NotNull validation rule, and make all other rules accept null
+                    } else {
+                        doValidation(var, val, entity);
+                    }
+                }
+            } else {
+                doValidation(var, value, entity);
+            }
+        }
+    }
+
+    /**
+     * Performs the actual validation. Values is never a sequence at this point.
+     *
+     * @param var
+     * @param value
+     * @param entity
+     */
+    protected abstract void doValidation(Variable var, Value value, VariableEntity entity);
+
+}

--- a/opal-core/src/main/java/org/obiba/opal/core/service/validation/CollectingCallback.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/validation/CollectingCallback.java
@@ -1,0 +1,30 @@
+package org.obiba.opal.core.service.validation;
+
+import org.obiba.magma.Value;
+import org.obiba.magma.Variable;
+import org.obiba.magma.VariableEntity;
+
+/**
+ * A BaseValidatingCallback impl that collects all the validation errors.
+ */
+public class CollectingCallback extends BaseValidatingCallback {
+
+    public CollectingCallback(ValidationTask validationTask) {
+        super(validationTask);
+    }
+
+    @Override
+    protected void doValidation(Variable var, Value value, VariableEntity entity) {
+        validationTask.validateAndCollect(var, value, entity);
+    }
+
+    @Override
+    public void onComplete() {
+
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return false;
+    }
+}

--- a/opal-core/src/main/java/org/obiba/opal/core/service/validation/ValidatingCallback.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/validation/ValidatingCallback.java
@@ -1,0 +1,47 @@
+package org.obiba.opal.core.service.validation;
+
+import org.obiba.magma.Value;
+import org.obiba.magma.Variable;
+import org.obiba.magma.VariableEntity;
+import org.obiba.magma.concurrent.ConcurrentValueTableReader;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+/**
+ * BaseValidatingCallback impl that wraps/decorates another callback and fails-fast (with a ValidationException)
+ */
+public class ValidatingCallback extends BaseValidatingCallback {
+
+    @NotNull
+    private final ConcurrentValueTableReader.ConcurrentReaderCallback delegate;
+
+    public ValidatingCallback(ValidationTask validationTask,
+                              ConcurrentValueTableReader.ConcurrentReaderCallback delegate) {
+        super(validationTask);
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void onBegin(List<VariableEntity> entities, Variable... variables) {
+        super.onBegin(entities, variables);
+        delegate.onBegin(entities, variables);
+    }
+
+    @Override
+    public void onComplete() {
+        delegate.onComplete();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return delegate.isCancelled();
+    }
+
+    @Override
+    protected void doValidation(Variable var, Value value, VariableEntity entity) {
+        //throws ValidationException if validation fails
+        this.validationTask.validate(var, value, entity);
+    }
+
+}

--- a/opal-core/src/main/java/org/obiba/opal/core/service/validation/ValidationTask.java
+++ b/opal-core/src/main/java/org/obiba/opal/core/service/validation/ValidationTask.java
@@ -1,0 +1,136 @@
+package org.obiba.opal.core.service.validation;
+
+import org.obiba.magma.Value;
+import org.obiba.magma.ValueTable;
+import org.obiba.magma.Variable;
+import org.obiba.magma.VariableEntity;
+import org.obiba.magma.concurrent.ConcurrentValueTableReader;
+import org.obiba.opal.core.service.ValidationService;
+import org.obiba.opal.core.support.MessageLogger;
+
+import javax.validation.ValidationException;
+import javax.validation.constraints.NotNull;
+import java.util.*;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Keeps the state of a running validation: logger, variables, constraints and results.
+ */
+public class ValidationTask {
+
+    @NotNull
+    private final MessageLogger logger;
+
+    private final ThreadFactory threadFactory;
+
+    private final Map<String, List<DataConstraint>> constraintMap = new HashMap<>();
+
+    private ValidationService.ValidationResult resultCollector = new ValidationService.ValidationResult();
+
+    public ValidationTask(MessageLogger logger, ThreadFactory threadFactory) {
+        this.logger = logger;
+        this.threadFactory = threadFactory;
+    }
+
+    public void addConstraints(Variable var, List<DataConstraint> constraints) {
+        constraintMap.put(var.getName(), constraints);
+    }
+
+    public boolean isEmpty() {
+        return constraintMap.isEmpty();
+    }
+
+    /**
+     * @return list of names of variables under validation
+     */
+    public List<String> getVariableNames() {
+        return new ArrayList<>(constraintMap.keySet());
+    }
+
+    /**
+     * Validates the given value for variable.
+     * @param variable
+     * @param value
+     * @param entity
+     * @throws ValidationException if the given value is not valid
+     */
+    public void validate(Variable variable, Value value, VariableEntity entity) throws ValidationException {
+        List<DataConstraint> constraints = constraintMap.get(variable.getName());
+        if (constraints != null) {
+            for (DataConstraint constraint: constraints) {
+                if (!constraint.isValid(value)) {
+                    String msg = getMessage(entity.getIdentifier(), variable.getName(), value.toString(), constraint);
+                    throw new ValidationException(msg);
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates the given value, updating the collector results if needed.
+     * @param variable
+     * @param value
+     * @param entity
+     */
+    public void validateAndCollect(Variable variable, Value value, VariableEntity entity) {
+        List<DataConstraint> constraints = constraintMap.get(variable.getName());
+        if (constraints != null) {
+            for (DataConstraint constraint: constraints) {
+                if (!constraint.isValid(value)) {
+                    String msg = getMessage(entity.getIdentifier(), variable.getName(), value.toString(), constraint);
+                    logger.warn(msg);
+                    resultCollector.addFailure(variable.getName(), constraint.getType(), value);
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates the complete table, returning the results.
+     * @param valueTable
+     * @return validation results
+     */
+    public ValidationService.ValidationResult validate(ValueTable valueTable) {
+
+        resultCollector = new ValidationService.ValidationResult();
+        logger.info("Validating table %s.%s", valueTable.getDatasource().getName(), valueTable.getName());
+
+        for (Map.Entry<String,List<DataConstraint>> entry: constraintMap.entrySet()) {
+            resultCollector.setRules(entry.getKey(), getRuleTypes(entry.getValue()));
+        }
+
+        Set<Variable> variables = new LinkedHashSet<>();
+        for (String var: getVariableNames()) {
+            variables.add(valueTable.getVariable(var));
+        }
+
+        ConcurrentValueTableReader.ConcurrentReaderCallback callback = new CollectingCallback(this);
+        ConcurrentValueTableReader.Builder builder =
+                ConcurrentValueTableReader.Builder.newReader() //
+                        .withThreads(threadFactory) //
+                        .from(valueTable) //
+                        .variablesFilter(variables) //
+                        .to(callback); //
+
+        builder.build().read();
+
+        return resultCollector;
+    }
+
+    private Set<String> getRuleTypes(List<DataConstraint> validators) {
+        Set<String> result = new HashSet<>();
+        for (DataConstraint validator: validators) {
+            result.add(validator.getType());
+        }
+        return result;
+    }
+
+    private static String getMessage(String entityId, String variable, String value, DataConstraint constraint) {
+        return String.format("Validation failed: EntityId %s, Variable %s, Value %s: %s",
+                entityId,
+                variable,
+                value,
+                constraint.getMessage());
+    }
+
+}

--- a/opal-core/src/test/java/org/obiba/opal/core/service/ValidationServiceImplTest.java
+++ b/opal-core/src/test/java/org/obiba/opal/core/service/ValidationServiceImplTest.java
@@ -4,16 +4,19 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.obiba.magma.*;
+import org.obiba.magma.Datasource;
+import org.obiba.magma.Value;
+import org.obiba.magma.ValueTable;
+import org.obiba.magma.Variable;
 import org.obiba.magma.support.StaticValueTable;
 import org.obiba.magma.type.TextType;
 import org.obiba.opal.core.service.ValidationService.ValidationResult;
-import org.obiba.opal.core.service.ValidationService.ValidationTask;
 import org.obiba.opal.core.service.validation.ValidatorFactory;
 import org.obiba.opal.core.service.validation.VocabularyConstraint;
 import org.obiba.opal.core.support.SystemOutMessageLogger;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Created by carlos on 8/5/14.
@@ -24,13 +27,16 @@ public class ValidationServiceImplTest {
 	private static final String INVALID_CODE = "foo";
 
     private ValidationServiceImpl validationService;
+    private AtomicBoolean validate;
 
     @Before
     public void setUp() {
+        validate = new AtomicBoolean(true); //we want to validate everything by default
     	validationService = new ValidationServiceImpl() {
             @Override
             public boolean isValidationEnabled(ValueTable valueTable) {
-                return true; //we want to validate everything
+
+                return validate.get(); //we want to validate everything
             }
         };
 
@@ -80,7 +86,7 @@ public class ValidationServiceImplTest {
     @Test
     public void testValidateWithVocabularyFailure() throws Exception {
         ValueTable table = createTable(INVALID_CODE, MagmaHelper.createVocabularyVariable());
-        ValidationResult result = validationService.validateNoTransaction(table, new SystemOutMessageLogger());
+        ValidationResult result = validationService.validate(table, new SystemOutMessageLogger());
 
 		Assert.assertTrue("should have failures", result.hasFailures());
 		Set<List<String>> pairs = result.getFailurePairs();
@@ -98,7 +104,7 @@ public class ValidationServiceImplTest {
     public void testValidateWithVocabularyNoFailures() throws Exception {
     	ValueTable table = createTable(VALID_CODE, MagmaHelper.createVocabularyVariable());
 
-        ValidationResult result = validationService.validateNoTransaction(table, new SystemOutMessageLogger());
+        ValidationResult result = validationService.validate(table, new SystemOutMessageLogger());
         checkVariableRules(result);
 
         Assert.assertFalse("should have no failures", result.hasFailures());
@@ -107,7 +113,7 @@ public class ValidationServiceImplTest {
     @Test
     public void testValidateRepeatableFailure() throws Exception {
         ValueTable table = createMultivalueTable(INVALID_CODE, MagmaHelper.createVocabularyVariable());
-        ValidationResult result = validationService.validateNoTransaction(table, new SystemOutMessageLogger());
+        ValidationResult result = validationService.validate(table, new SystemOutMessageLogger());
 
         Assert.assertTrue("should have failures", result.hasFailures());
         Set<List<String>> pairs = result.getFailurePairs();
@@ -125,17 +131,18 @@ public class ValidationServiceImplTest {
     public void testValidateRepeatableNoFailures() throws Exception {
         ValueTable table = createMultivalueTable(VALID_CODE, MagmaHelper.createVocabularyVariable());
 
-        ValidationResult result = validationService.validateNoTransaction(table, new SystemOutMessageLogger());
+        ValidationResult result = validationService.validate(table, new SystemOutMessageLogger());
         checkVariableRules(result);
 
         Assert.assertFalse("should have no failures", result.hasFailures());
     }
 
     @Test
-    public void testValidateNoValidationNoTask() throws Exception {
+    public void testValidateNoValidationNoResult() throws Exception {
+        validate.set(false); //disable validation
         ValueTable table = createTable(INVALID_CODE, MagmaHelper.createVariable());
-        ValidationTask task = validationService.createValidationTask(table, new SystemOutMessageLogger());
-        Assert.assertNull("should have no validation task", task);
+        ValidationResult result = validationService.validate(table, new SystemOutMessageLogger());
+        Assert.assertNull("should have no validation result", result);
     }
 
     @Test
@@ -164,7 +171,7 @@ public class ValidationServiceImplTest {
     }
 
     private boolean isValid(ValueTable valueTable) {
-        ValidationResult vd = validationService.validateNoTransaction(valueTable, new SystemOutMessageLogger());
+        ValidationResult vd = validationService.validate(valueTable, new SystemOutMessageLogger());
         return vd == null || !vd.hasFailures();
     }
 

--- a/opal-shell/src/main/java/org/obiba/opal/shell/commands/ValidateCommand.java
+++ b/opal-shell/src/main/java/org/obiba/opal/shell/commands/ValidateCommand.java
@@ -68,15 +68,15 @@ public class ValidateCommand
 
     private int executeValidation(ValueTable valueTable) {
         MessageLogger logger = new OpalShellMessageAdapter(getShell());
-        ValidationService.ValidationTask task =  validationService.createValidationTask(valueTable, logger);
+
         try {
-            final ValidationResult result;
-            if (task != null) {
-                result = task.validate();
-            } else {
-                //no validation for the table
+            ValidationResult result = validationService.validate(valueTable, logger);
+
+            if (result == null) {
+                //no validation required/enabled: create an empty result
                 result = new ValidationResult();
             }
+
             resultBuilder.setHasFailures(result.hasFailures());
             resultBuilder.setRules(getRulesJson(result));
             resultBuilder.setFailures(getFailuresJson(result));


### PR DESCRIPTION
Huge refactoring on validation:
-Removed ValidationTask from ValidationService interface (implementation class only)
-Moved InternalValidationTask out of ValidationServiceImpl, and now its called ValidationTask
-Added method ValidationService.createValidatingCallback, simplifying interaction at EsValuesIndexManager
-Validation now uses ConcurrentValueTableReader (and callbacks) and so its as fast as indexing